### PR TITLE
Revert "chore: replace `&#x27;` and `&#x2F` with `&#39;` and `&#47;`"

### DIFF
--- a/src/encode/html_entity/mod.rs
+++ b/src/encode/html_entity/mod.rs
@@ -81,7 +81,7 @@ escape_impl! {
     b'&' => b"&amp;",
     b'<' => b"&lt;",
     b'>' => b"&gt;",
-    b'\'' => b"&#39;",
+    b'\'' => b"&#x27;",
 }
 
 escape_impl! {
@@ -90,7 +90,7 @@ escape_impl! {
     b'<' => b"&lt;",
     b'>' => b"&gt;",
     b'"' => b"&quot;",
-    b'\'' => b"&#39;",
+    b'\'' => b"&#x27;",
 }
 
 escape_impl! {
@@ -99,8 +99,8 @@ escape_impl! {
     b'<' => b"&lt;",
     b'>' => b"&gt;",
     b'"' => b"&quot;",
-    b'\'' => b"&#39;",
-    b'/' => b"&#47;",
+    b'\'' => b"&#x27;",
+    b'/' => b"&#x2F;",
 }
 
 macro_rules! encode_impl {
@@ -250,7 +250,7 @@ encode_impl! {
     /// * `&` => `&amp;`
     /// * `<` => `&lt;`
     /// * `>` => `&gt;`
-    /// * `'` => `&#39;`
+    /// * `'` => `&#x27;`
     escape_single_quote;
     /// Encode text used in a single-quoted attribute.
     encode_single_quoted_attribute;
@@ -269,7 +269,7 @@ encode_impl! {
     /// * `<` => `&lt;`
     /// * `>` => `&gt;`
     /// * `"` => `&quot;`
-    /// * `'` => `&#39;`
+    /// * `'` => `&#x27;`
     escape_quote;
     /// Encode text used in a quoted attribute.
     encode_quoted_attribute;
@@ -288,8 +288,8 @@ encode_impl! {
     /// * `<` => `&lt;`
     /// * `>` => `&gt;`
     /// * `"` => `&quot;`
-    /// * `'` => `&#39;`
-    /// * `/` => `&#47;`
+    /// * `'` => `&#x27;`
+    /// * `/` => `&#x2F;`
     escape_safe;
     /// Encode text to prevent special characters functioning.
     encode_safe;

--- a/tests/html_entity.rs
+++ b/tests/html_entity.rs
@@ -65,7 +65,7 @@ const SAFE_CASES: [(&str, &str); 7] = [
     ("&quot;bread&quot; &amp; 奶油", "\"bread\" & 奶油"),
     ("&lt; less than", "< less than"),
     ("greater than &gt;", "greater than >"),
-    ("https:&#47;&#47;magiclen.org", "https://magiclen.org"),
+    ("https:&#x2F;&#x2F;magiclen.org", "https://magiclen.org"),
 ];
 
 #[test]
@@ -126,7 +126,7 @@ const UNQUOTED_ATTRIBUTE_CASES: [(&str, &str); 7] = [
     ("&quot;bread&quot;&#x20;&amp;&#x20;奶油", "\"bread\" & 奶油"),
     ("&lt;&#x20;less&#x20;than", "< less than"),
     ("greater&#x20;than&#x20;&gt;", "greater than >"),
-    ("https&#x3A;&#47;&#47;magiclen&#x2E;org", "https://magiclen.org"),
+    ("https&#x3A;&#x2F;&#x2F;magiclen&#x2E;org", "https://magiclen.org"),
     ("d&#x2D;none&#x20;m&#x2D;0", "d-none m-0"),
 ];
 


### PR DESCRIPTION
Reverts magiclen/html-escape#2

Umm... Hex would be better than decimal, I think.