### PR TITLE
update unsafe set_len calls

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -8,9 +8,7 @@ pub(crate) fn write_hex_to_vec(e: u8, output: &mut Vec<u8>) {
 
     let length = output.len();
 
-    unsafe {
-        output.set_len(length + 6);
-    }
+    output.resize(length + 6, 0);
 
     let output = &mut output[length..];
 
@@ -67,9 +65,7 @@ pub(crate) fn write_char_to_vec(c: char, output: &mut Vec<u8>) {
 
     let current_length = output.len();
 
-    unsafe {
-        output.set_len(current_length + width);
-    }
+    output.resize(current_length + width);
 
     c.encode_utf8(&mut output[current_length..]);
 }


### PR DESCRIPTION
No functional changes intended.

These `set_len` calls were unsound: `set_len` requires that the elements old_len..new_len were initialized:
* https://doc.rust-lang.org/std/vec/struct.Vec.html#method.set_len